### PR TITLE
fix(query_builder): resolve SQLite unrecognized token error for temporal fields

### DIFF
--- a/bottle-orm/src/query_builder.rs
+++ b/bottle-orm/src/query_builder.rs
@@ -50,8 +50,8 @@
 use futures::future::BoxFuture;
 use heck::ToSnakeCase;
 use sqlx::{
-    any::{AnyArguments, AnyRow},
     Any, Arguments, Decode, Encode, FromRow, Row, Type,
+    any::{AnyArguments, AnyRow},
 };
 use std::marker::PhantomData;
 use uuid::Uuid;
@@ -61,11 +61,11 @@ use uuid::Uuid;
 // ============================================================================
 
 use crate::{
+    AnyImpl, Error,
     database::{Connection, Drivers},
     model::{ColumnInfo, Model},
     temporal::{self, is_temporal_type},
     value_binding::ValueBinder,
-    AnyImpl, Error,
 };
 
 // ============================================================================
@@ -1203,7 +1203,7 @@ where
                     let col_snake = col_info.column.to_snake_case();
                     let sql_type = col_info.sql_type;
                     if self.select_columns.contains(&col_snake) {
-                        if is_temporal_type(sql_type) {
+                        if is_temporal_type(sql_type) && matches!(self.driver, Drivers::Postgres) {
                             if !self.joins_clauses.is_empty() {
                                 args.push(format!(
                                     "to_json(\"{}\".\"{}\") #>> '{{}}' AS \"{}\"",
@@ -1227,7 +1227,7 @@ where
                     .iter()
                     .map(|c| {
                         let col_snake = c.column.to_snake_case();
-                        if is_temporal_type(c.sql_type) {
+                        if is_temporal_type(c.sql_type) && matches!(self.driver, Drivers::Postgres) {
                             if !self.joins_clauses.is_empty() {
                                 format!(
                                     "to_json(\"{}\".\"{}\") #>> '{{}}' AS \"{}\"",


### PR DESCRIPTION
## Description

This PR fixes a compatibility issue in Bottle ORM where queries using filters (e.g., `filter("id", "=", value).first()`) would fail with `unrecognized token: "#"` when using SQLite, even if the filter was on a non-temporal column. The error occurred specifically in models containing temporal fields like `DateTime<Utc>` or `NaiveDateTime`.

### Root Cause
The `select_args_sql` method in `query_builder.rs` was unconditionally applying PostgreSQL-specific JSON extraction syntax (`to_json(column) #>> '{{}}'`) to temporal columns across all database drivers (PostgreSQL, MySQL, SQLite). The `#>>` operator is not supported in SQLite, causing the syntax error.

### Solution
Modified the `select_args_sql` method to conditionally apply the JSON syntax only for PostgreSQL by checking `matches!(self.driver, Drivers::Postgres)`. For SQLite and MySQL, temporal columns are now selected as standard text fields, aligning with native database handling.

### Changes Made
- **File:** `Bottle-ORM/bottle-orm/src/query_builder.rs`
  - Line ~1206: Updated `if is_temporal_type(sql_type) {` to `if is_temporal_type(sql_type) && matches!(self.driver, Drivers::Postgres) {`
  - Line ~1230: Applied the same conditional check in the column mapping closure.

### Testing
- Previously failing queries now execute successfully.
- Temporal fields are correctly handled via the `temporal` module for serialization/deserialization.
- No regressions in existing functionality.

### Impact
- **Positive:** Ensures seamless SQLite compatibility for models with temporal fields.
- **Scope:** Changes are isolated to `select_args_sql`.
- **Backward Compatibility:** Fully maintained.
- **Performance:** No impact; only affects SQL generation for temporal columns in non-PostgreSQL drivers.